### PR TITLE
fix(utils.ts): add

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,4 +1,4 @@
-// frontend/src/app/lib/utils/utils.ts
+// frontend/src/lib/utils/utils.ts
 
 // https://stackoverflow.com/questions/77932960/what-needs-to-be-added-to-path-lib-utils-when-tryinng-to-use-shadcn-ui-c
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,26 @@
+// frontend/src/app/lib/utils/utils.ts
+
+// https://stackoverflow.com/questions/77932960/what-needs-to-be-added-to-path-lib-utils-when-tryinng-to-use-shadcn-ui-c
+
+// https://github.com/shadcn-ui/ui/blob/main/apps/www/lib/utils.ts
+
+import * as React from "react"
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+export function formatDate(input: string | number): string {
+  const date = new Date(input)
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+export function absoluteUrl(path: string) {
+  return `${process.env.NEXT_PUBLIC_APP_URL}${path}`
+}


### PR DESCRIPTION
// frontend/src/app/lib/utils/utils.ts

// https://stackoverflow.com/questions/77932960/what-needs-to-be-added-to-path-lib-utils-when-tryinng-to-use-shadcn-ui-c

// https://github.com/shadcn-ui/ui/blob/main/apps/www/lib/utils.ts

fix error when running `npm run dev`

Build Error
Failed to compile

Next.js (14.2.6)
./src/components/ui/button.tsx:5:1
Module not found: Can't resolve '@/lib/utils'
  3 | import { cva, type VariantProps } from "class-variance-authority"
  4 |
> 5 | import { cn } from "@/lib/utils"
    | ^
  6 |
  7 | const buttonVariants = cva(
  8 |   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
./src/components/core/Navbar.tsx
./src/app/page.tsx
This error occurred during the build process and can only be dismissed by fixing the error.